### PR TITLE
tipado de función y ejemplo sin return

### DIFF
--- a/src/pilotos.ts
+++ b/src/pilotos.ts
@@ -1,3 +1,5 @@
+type FormaDeConducir = (pista: Pista) => number
+
 export class Piloto {
   formaConducir: (pista: Pista) => number = cabulero
 
@@ -5,7 +7,7 @@ export class Piloto {
     return this.formaConducir(pista)
   }
 }
-
+// Puedo no tipar la función y el lenguaje infiere el tipo automáticamente.
 export const audaz = (tiempoCurva = 1) => {
   return (pista: Pista): number => {
     return pista.cantidadCurvas * tiempoCurva * pista.largoPorVuelta
@@ -14,15 +16,15 @@ export const audaz = (tiempoCurva = 1) => {
 
 export const VALOR_BASE = 30
 
-export const virtuoso = (nivelVirtuosismo = 1) => {
+export const virtuoso: (_: number) => FormaDeConducir = (nivelVirtuosismo = 1) => {
   return (pista: Pista): number => {
     return pista.largoPorVuelta * (VALOR_BASE / nivelVirtuosismo)
   }
 }
 
-export const cabulero = (pista: Pista): number => {
-  return pista.largoPorVuelta * efectoMultiplicador(pista)
-}
+// Puedo evitar las llaves y el return si es una arrow function de pregunta y no de acción.
+export const cabulero: FormaDeConducir = (pista: Pista): number => pista.largoPorVuelta * efectoMultiplicador(pista)
+
 
 const efectoMultiplicador = (pista: Pista) => {
   return pista.nombrePar() ? MULTIPLICADOR_PAR : MULTIPLICADOR_IMPAR


### PR DESCRIPTION
Agrego el tapado de la función del strategy. Dejo un ejemplo sin tirar para ver como infiere automáticamente. Además dejo una Arrow función sin llaves ni return cuando es una función de pregunta. 